### PR TITLE
add intensity to the RadarDetection class

### DIFF
--- a/LibCarla/source/carla/sensor/data/RadarData.h
+++ b/LibCarla/source/carla/sensor/data/RadarData.h
@@ -24,11 +24,12 @@ namespace data {
     float azimuth;  // rad
     float altitude; // rad
     float depth;    // m
+    float intensity;
   };
 
   class RadarData {
     static_assert(sizeof(float) == sizeof(uint32_t), "Invalid float size");
-    static_assert(sizeof(float) * 4 == sizeof(RadarDetection), "Invalid RadarDetection size");
+    static_assert(sizeof(float) * 5 == sizeof(RadarDetection), "Invalid RadarDetection size");
 
   public:
     explicit RadarData() = default;

--- a/PythonAPI/carla/source/libcarla/SensorData.cpp
+++ b/PythonAPI/carla/source/libcarla/SensorData.cpp
@@ -142,6 +142,7 @@ namespace data {
         << ", azimuth=" << std::to_string(det.azimuth)
         << ", altitude=" << std::to_string(det.altitude)
         << ", depth=" << std::to_string(det.depth)
+        << ", intensity=" << std::to_string(det.intensity)
         << ')';
     return out;
   }
@@ -509,6 +510,7 @@ void export_sensor_data() {
     .def_readwrite("azimuth", &csd::RadarDetection::azimuth)
     .def_readwrite("altitude", &csd::RadarDetection::altitude)
     .def_readwrite("depth", &csd::RadarDetection::depth)
+    .def_readwrite("intensity", &csd::RadarDetection::intensity)
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -1635,6 +1635,8 @@ void UActorBlueprintFunctionLibrary::SetRadar(
       RetrieveActorAttributeToFloat("range", Description.Variations, 100.0f) * TO_CENTIMETERS);
   Radar->SetPointsPerSecond(
       RetrieveActorAttributeToInt("points_per_second", Description.Variations, 1500));
+  Radar->SetAtmospAttenRate(
+      RetrieveActorAttributeToFloat("atmosphere_attenuation_rate", Description.Variations, 0.004));
 }
 
 #undef CARLA_ABFL_CHECK_ACTOR

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.cpp
@@ -59,11 +59,28 @@ void ARadar::SetPointsPerSecond(int NewPointsPerSecond)
   RadarData.SetResolution(PointsPerSecond);
 }
 
+void ARadar::SetAtmospAttenRate(float NewAtmospAttenRate)
+{
+  AtmospAttenRate = NewAtmospAttenRate;
+}
+
 void ARadar::BeginPlay()
 {
   Super::BeginPlay();
 
   PrevLocation = GetActorLocation();
+}
+
+float ARadar::ComputeIntensity(const FRadarDetection& RawDetection) const
+{
+  const float Distance = RawDetection.depth;
+
+  const float AttenAtm = AtmospAttenRate;
+  const float AbsAtm = exp(-AttenAtm * Distance);
+
+  const float IntRec = AbsAtm;
+
+  return IntRec;
 }
 
 void ARadar::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTime)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.cpp
@@ -71,10 +71,8 @@ void ARadar::BeginPlay()
   PrevLocation = GetActorLocation();
 }
 
-float ARadar::ComputeIntensity(const FRadarDetection& RawDetection) const
+float ARadar::ComputeIntensity(const float& Distance) const
 {
-  const float Distance = RawDetection.depth;
-
   const float AttenAtm = AtmospAttenRate;
   const float AbsAtm = exp(-AttenAtm * Distance);
 
@@ -185,7 +183,8 @@ void ARadar::SendLineTraces(float DeltaTime)
         ray.RelativeVelocity,
         ray.AzimuthAndElevation.X,
         ray.AzimuthAndElevation.Y,
-        ray.Distance
+        ray.Distance,
+        ComputeIntensity(ray.Distance)
       });
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.h
@@ -23,6 +23,7 @@ class CARLA_API ARadar : public ASensor
   GENERATED_BODY()
 
   using FRadarData = carla::sensor::data::RadarData;
+  using FRadarDetection = carla::sensor::data::RadarDetection;
 
 public:
 
@@ -44,6 +45,9 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Radar")
   void SetPointsPerSecond(int NewPointsPerSecond);
 
+  UFUNCTION(BlueprintCallable, Category = "Radar")
+  void SetAtmospAttenRate(float NewAtmospAttenRate);
+
 protected:
 
   void BeginPlay() override;
@@ -63,7 +67,12 @@ protected:
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Detection")
   int PointsPerSecond;
 
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Detection")
+  float AtmospAttenRate;
+
 private:
+
+  float ComputeIntensity(const FRadarDetection& RawDetection) const;
 
   void CalculateCurrentVelocity(const float DeltaTime);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Radar.h
@@ -23,7 +23,6 @@ class CARLA_API ARadar : public ASensor
   GENERATED_BODY()
 
   using FRadarData = carla::sensor::data::RadarData;
-  using FRadarDetection = carla::sensor::data::RadarDetection;
 
 public:
 
@@ -72,7 +71,7 @@ protected:
 
 private:
 
-  float ComputeIntensity(const FRadarDetection& RawDetection) const;
+  float ComputeIntensity(const float& Distance) const;
 
   void CalculateCurrentVelocity(const float DeltaTime);
 


### PR DESCRIPTION
Add the same intensity loss which is computed for the LIDAR, to the radar model.

The intensity loss is computed as follows:

![image](https://user-images.githubusercontent.com/59822141/178103997-46babb26-ef13-42cf-9c0d-b4c2e7bb7fe2.png)
